### PR TITLE
Add ports public info

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Install using `pip`!
 
 ```sh
-pip install iic2343
+$ pip install iic2343
 ```
 
 ## Usage
@@ -25,20 +25,76 @@ instance.write(4, bytearray([0x00, 0x00, 0x00, 0x20, 0x00]))
 instance.end()
 ```
 
+### Methods
+
 Here, a `Basys3` instance has 3 methods:
 
-### `begin`
+#### `begin`
 
 The method receives an optional `port_number` parameter (in needs to be an `int`). If the parameter is not present and there is only one available serial port on your machine, the `Basys3` instance will use that serial port. Otherwise, it will raise an exception. The method initializes a port to `write` to.
 
-### `write`
+#### `write`
 
 The method receives an `address` parameter (an `int`) and a `word` parameter (a `bytearray`). It then attempts to write the `word` on the specified `address`. If the `Basys3` instance fails, it returns a `0`. Otherwise, it returns an `int`.
 
-### `end`
+#### `end`
 
 The method receives no parameters, and simply closes the port initialized on the `begin` method.
 
+### Attributes
+
+The `Basys3` instance also has 1 attribute:
+
+#### `available_ports`
+
+This attribute has a list with all the available ports (the ports are [`ListPortInfo`](https://pythonhosted.org/pyserial/tools.html#serial.tools.list_ports.ListPortInfo) objects). You don't **need** to use this attribute, but it might come in handy if you want to generate a GUI for your users or something like that.
+
+## CLI
+
+This module also includes a CLI! It is quite simple, but it might be useful to see ports on your machine. The CLI works as follows:
+
+```sh
+$ iic2343 --help
+usage: iic2343 [-h] [-v] {ports} ...
+
+Command line interface tool for iic2343.
+
+positional arguments:
+  {ports}        Action to be executed.
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -v, --version  show program's version number and exit
+```
+
+That was the `--help` flag. Use it when you're not sure how something works! To see a list of your available ports, run the following command on your terminal:
+
+```sh
+$ iic2343 ports
+(0) ttyS0
+      desc: ttyS0
+(1) ttyUSB0
+      desc: n/a
+(2) ttyUSB1
+      desc: CP2102 USB to UART Bridge Controller
+3 ports found
+```
+
+You can also use the `--verbose` flag to get a bit more information about each port:
+
+```sh
+$ iic2343 ports --verbose
+(0) /dev/ttyS0
+      desc: ttyS0
+      hwid: PNP0501
+(1) /dev/ttyUSB0
+      desc: n/a
+      hwid: PNP0502
+(2) /dev/ttyUSB1
+      desc: CP2102 USB to UART Bridge Controller
+      hwid: USB VID:PID=10C4:EA60 SER=0001 LOCATION=2-1.6
+3 ports found
+```
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,28 @@
-# IIC2343
+<h1 align="center">IIC2343</h1>
+
+<p align="center">
+    <em>
+        Write to the Basys3 ROM directly.
+    </em>
+</p>
+
+<p align="center">
+<a href="https://pypi.org/project/iic2343" target="_blank">
+    <img src="https://img.shields.io/pypi/v/iic2343?label=version&logo=python&logoColor=%23fff&color=306998" alt="PyPI - Version">
+</a>
+
+<a href="https://github.com/daleal/iic2343/actions?query=workflow%3Atests" target="_blank">
+    <img src="https://img.shields.io/github/workflow/status/daleal/iic2343/tests?label=tests&logo=python&logoColor=%23fff" alt="Tests">
+</a>
+
+<a href="https://codecov.io/gh/daleal/iic2343" target="_blank">
+    <img src="https://img.shields.io/codecov/c/gh/daleal/iic2343?label=coverage&logo=codecov&logoColor=ffffff" alt="Coverage">
+</a>
+
+<a href="https://github.com/daleal/iic2343/actions?query=workflow%3Alinters" target="_blank">
+    <img src="https://img.shields.io/github/workflow/status/daleal/iic2343/linters?label=linters&logo=github" alt="Linters">
+</a>
+</p>
 
 ## Installation
 

--- a/iic2343/cli/core.py
+++ b/iic2343/cli/core.py
@@ -1,0 +1,22 @@
+"""
+A module to route the CLI traffic.
+"""
+
+from typing import Any
+
+from iic2343.cli.generators import generate_main_parser
+from iic2343.cli.utils import display_ports
+from iic2343.core import Basys3
+
+
+def dispatcher(*args: Any, **kwargs: Any) -> None:
+    """
+    Main CLI method, recieves the command line action and dispatches it to
+    the corresponding method.
+    """
+    parser = generate_main_parser()
+    parsed_args = parser.parse_args(*args, **kwargs)
+
+    basys3 = Basys3()
+
+    display_ports(basys3.available_ports, parsed_args.verbose)

--- a/iic2343/cli/generators.py
+++ b/iic2343/cli/generators.py
@@ -1,0 +1,39 @@
+"""
+A module to hold the CLI parser generators.
+"""
+
+from argparse import ArgumentParser, _SubParsersAction
+
+import iic2343
+from iic2343.cli.utils import setup_serial_ports_arguments
+
+
+def generate_main_parser() -> ArgumentParser:
+    """Generates the main parser."""
+    # Create parser
+    parser = ArgumentParser(
+        description="Command line interface tool for iic2343.",
+    )
+
+    # Add version flag
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"iic2343 version {iic2343.__version__}",
+    )
+
+    # Create subparsers
+    subparsers = parser.add_subparsers(help="Action to be executed.")
+
+    # Serial ports subparser
+    generate_serial_ports_subparser(subparsers)
+
+    return parser
+
+
+def generate_serial_ports_subparser(subparsers: _SubParsersAction) -> ArgumentParser:
+    """Generates the serial ports action for the parser."""
+    serial_ports_subparser = subparsers.add_parser("ports")
+    serial_ports_subparser.set_defaults(action="ports")
+    return setup_serial_ports_arguments(serial_ports_subparser)

--- a/iic2343/cli/utils.py
+++ b/iic2343/cli/utils.py
@@ -1,0 +1,44 @@
+"""
+A module to hold some CLI utilities.
+"""
+
+from argparse import ArgumentParser
+from typing import List
+
+from serial.tools.list_ports_common import ListPortInfo
+
+
+def setup_serial_ports_arguments(parser: ArgumentParser) -> ArgumentParser:
+    """Sets up the serial ports action for the parser."""
+    # Verbose
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="verbose",
+        action="store_true",
+        help="Show verbose output.",
+    )
+
+    return parser
+
+
+def display_ports(ports: List[ListPortInfo], verbose: bool) -> None:
+    """Prints the ports to the console."""
+    processed = [format_port(index, port, verbose) for index, port in enumerate(ports)]
+    for port in processed:
+        print(port)
+    print(f"{len(processed)} {'ports' if len(processed) != 1 else 'port'} found")
+
+
+def format_port(index: int, port: ListPortInfo, verbose: bool) -> str:
+    """
+    Given an index, a port and a verbose flag, returns a formatted
+    string that gives the relevant information of said port.
+    """
+    name = port.device if verbose else port.name
+    description = (
+        (f"      desc: {port.description}\n" f"      hwid: {port.hwid}")
+        if verbose
+        else (f"      desc: {port.description}")
+    )
+    return f"({index}) {name}\n{description}"

--- a/iic2343/core.py
+++ b/iic2343/core.py
@@ -29,7 +29,7 @@ class Basys3:
     @property
     def available_ports(self) -> List[ListPortInfo]:
         """Get available ports."""
-        return list_ports.comports()
+        return sorted(list_ports.comports())
 
     def begin(self, port_number: Optional[int] = None) -> None:
         """Configure and initialize the port to be used."""

--- a/iic2343/core.py
+++ b/iic2343/core.py
@@ -1,9 +1,10 @@
 """Core module for the package. It holds the main object to be used."""
 
-from typing import Optional
+from typing import List, Optional
 
 import serial
 from serial.tools import list_ports
+from serial.tools.list_ports_common import ListPortInfo
 
 from iic2343.utils import (
     can_be_written,
@@ -25,12 +26,16 @@ class Basys3:
     def __init__(self) -> None:
         self.__port = serial.Serial()
 
+    @property
+    def available_ports(self) -> List[ListPortInfo]:
+        """Get available ports."""
+        return list_ports.comports()
+
     def begin(self, port_number: Optional[int] = None) -> None:
         """Configure and initialize the port to be used."""
-        os_ports = list_ports.comports()
-        validate_port_selection(port_number, os_ports)
+        validate_port_selection(port_number, self.available_ports)
         self.__port = configure_port(self.__port)
-        self.__port.port = os_ports[port_number or 0].device
+        self.__port.port = self.available_ports[port_number or 0].device
         open_port(self.__port)
 
     def end(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ maintainers = ["Daniel Leal <dlleal@uc.cl>"]
 readme = "README.md"
 repository = "https://github.com/daleal/iic2343"
 documentation = "https://github.com/daleal/iic2343#readme"
+packages = [
+    { include = "iic2343" },
+]
 exclude = [
     ".github",
     ".flake8",
@@ -31,6 +34,9 @@ mypy = "^0.790"
 pylint = "^2.6.0"
 pytest = "^6.1.1"
 pytest-cov = "^2.10.1"
+
+[tool.poetry.plugins."console_scripts"]
+iic2343 = "iic2343.cli.core:dispatcher"
 
 [tool.poetry.urls]
 "Issue Tracker" = "https://github.com/daleal/iic2343/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "iic2343"
 version = "0.1.1"
-description = "Write to the Basys3 directly."
+description = "Write to the Basys3 ROM directly."
 license = "MIT"
 authors = ["Daniel Leal <dlleal@uc.cl>"]
 maintainers = ["Daniel Leal <dlleal@uc.cl>"]


### PR DESCRIPTION
## Description

This Pull Request adds an attribute to the `Basys3` object that returns the ports. Also, it adds a CLI that lets the users see information about the same ports without needing to write Python (it might be useful to select the desired port immediately).

## Requirements

None.

## Additional changes

Make some aesthetic changes to the `README.md` and to the `pyproject.toml`
